### PR TITLE
Initial checkin of SparkCC Code of Conduct

### DIFF
--- a/sparkcc-code_of_conduct.md
+++ b/sparkcc-code_of_conduct.md
@@ -1,0 +1,60 @@
+# SparkCC - Code of Conduct
+
+SparkCC is a community of makers based on the New South Wales Central Coast. 
+
+We provide a safe and welcoming environment in which makers of all backgrounds and skill levels can create, learn and collaborate. To this end, all SparkCC members and visitors are required to abide by a code of conduct.
+
+_Note: The SparkCC Code of Conduct is based upon the **Linux Australia** [Code of Conduct](https://linux.conf.au/attend/code-of-conduct/)._
+
+## Be respectful
+
+Respect yourself, and respect others. Be courteous to those around you. If someone indicates they don't wish to be photographed, respect that wish. If someone indicates they would like to be left alone, let them be. This applies to both the SparkCC makerspace and SparkCC online spaces.
+
+## Be aware
+
+We ask everyone to be aware that we will not tolerate intimidation, harassment, or any abusive, discriminatory or derogatory behaviour by anyone in a SparkCC space or at a SparkCC event.
+
+Incidents may be reported to the SparkCC Committee as outlined in _Reporting incidents_ below. Should the Commitee consider it appropriate, measures they may take include:
+
+    - The individual may be told to apologise
+    - The individual may be told to stop/modify their behaviour appropriately
+    - The individual may be warned that enforcement action may be taken if the behaviour continues
+    - The individual may be asked to immediately leave the space and/or be prohibited from returning
+    - The individual may have any existing SparkCC membership suspended
+    - The individual may have any existing SparkCC membership cancelled
+    - The incident may be reported to the appropriate authorities
+
+## What does that mean for me?
+
+All SparkCC members and visitors in a SparkCC space or at a SparkCC event must not engage in any intimidation, harassment, or any abusive, discriminatory or derogatory behaviour.
+
+Here are some examples of behaviours which are not appropriate:
+
+    - Offensive verbal or written remarks related but not limited to gender, sex, sexual orientation, disability, physical appearance, body size, race or religion
+    - Sexual or violent images in public spaces (including presentation slides)
+    - Deliberate intimidation
+    - Stalking or following
+    - Unwanted private/direct online messaging
+    - Unwanted photography or recording
+    - Sustained disruption of presentations or other events
+    - Intoxication
+    - Inappropriate physical contact
+    - Unwelcome sexual attention
+    - Sexist, racist, or other exclusionary jokes
+    - Unwarranted exclusion based on attributes such as (but not limited to) age, gender, sex, sexual orientation, disability, physical appearance, body size, race, religion
+
+We want everyone to have a great time at SparkCC. Be excellent to each other.
+
+## Reporting incidents
+
+Incidents should be reported _as soon as possible_ to the SparkCC Committee at committee@sparkcc.org.
+
+If you are uncomfortable reporting an incident to the entire SparkCC Committee it should be reported directly to an [individual committee member](https://wiki.sparkcc.org/People#committee).
+
+All incidents will remain confidential, be taken seriously and treated appropriately with discretion.
+
+## Questions
+
+If you’re not sure about anything you’ve just read please contact the SparkCC Committee at committee@sparkcc.org.
+
+This document is available to be re-used or modified under the terms of the Creative Commons Attribution-ShareAlike 3.0 Australia licence, available from [CreativeCommons.org](https://creativecommons.org/licenses/by-sa/3.0/au/).


### PR DESCRIPTION
This is an initial proposal for a SparkCC Code of Conduct.

It is based upon the Linux Australia [Code of Conduct](https://linux.conf.au/attend/code-of-conduct/). Appropriate changes have been made to reflect SparkCC being an organisation with physical and online spaces rather than a single event.

All SparkCC members are invited to comment to raise objections or suggest changes by 23:59 on 2022-02-25.

Adoption of this Code of Conduct will then be voted upon at the 2021/22 SparkCC AGM on 2022-03-01.