### PR TITLE
Constitution updates 2023

### DIFF
--- a/sparkcc-constitution.md
+++ b/sparkcc-constitution.md
@@ -169,7 +169,7 @@ A right, privilege or obligation which a person has by reason of being a member 
 
 ### 2.7 Fees and subscriptions
 
-1. A member of the association must pay to the association a monthly membership fee of $50 or, if some other amount is determined by the committee, that other amount:
+1. A member of the association must pay to the association a monthly membership fee as defined in the [SparkCC Membership Policy](https://wiki.sparkcc.org/policies/membership), or if some other amount is determined by the committee, that other amount:
 
     1. Membership fees are to paid one month in advance
     2. No refunds will be given on any fees paid in advance.

--- a/sparkcc-constitution.md
+++ b/sparkcc-constitution.md
@@ -1,4 +1,4 @@
-# SparkCC Makerspace
+# SparkCC Incorporated
 
 **Constitution**
 
@@ -63,7 +63,7 @@ _Document Version 5.1: July 2022_
 
 ### 1.1 Vision
 
-1. SparkCC believes that making things promotes a strong sense of purpose and personal well-being. We seek to advance the social welfare of Central Coast residents by empowering them to make anything that they can imagine.
+1. SparkCC Incorporated _("SparkCC")_ believes that making things promotes a strong sense of purpose and personal well-being. We seek to advance the social welfare of Central Coast residents by empowering them to make anything that they can imagine.
 
 ### 1.2 Mission
 

--- a/sparkcc-constitution.md
+++ b/sparkcc-constitution.md
@@ -63,7 +63,7 @@ _Document Version 5.1: July 2022_
 
 ### 1.1 Vision
 
-1. SparkCC Incorporated _("SparkCC")_ believes that making things promotes a strong sense of purpose and personal well-being. We seek to advance the social welfare of Central Coast residents by empowering them to make anything that they can imagine.
+1. SparkCC Incorporated _("SparkCC")_ believes that making things in a community setting promotes a strong sense of purpose, enhances personal well-being and relieves social isolation. SparkCC is established to be a charity whose purpose is to advance the social welfare and mental health of Central Coast residents by operating a community makerspace in which they are empowered to work with others and make anything that they can imagine.
 
 ### 1.2 Mission
 


### PR DESCRIPTION
This PR adds some minor housekeeping changes to the SparkCC constitution to be discussed and voted upon at the 2022-2023 SparkCC AGM:

1. Update references to the organisation to our full legal name: _SparkCC Incorporated_.

    This obvious error was pointed out to us by a third party and needs to be rectified for legal purposes.

2. Update membership fee to point to the SparkCC Membership Policy on the SparkCC wiki.

    This allows SparkCC to update membership tiers without changing the constitution (which is a time-consuming and costly process). Membership fees will still only be modified by a general vote passed by a majority of members, as has previously been the case. Changes to the policy are transparent via the wiki's [history feature](https://wiki.sparkcc.org/h/en/policies/membership).
    
3. Update _Vision_ to explicitly include SparkCC's social aims.

    Explicitly mentioning our social aims in our vision is important for organisations to recognise our NFP/Charitable status.